### PR TITLE
Feature/network selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ cython_debug/
 
 .vscode/
 data/*
+.DS_Store

--- a/models/droplet.py
+++ b/models/droplet.py
@@ -13,6 +13,7 @@ class Droplet(db.Model):
 	container_cores = db.Column(db.Integer, nullable=True)
 	container_memory = db.Column(db.Integer, nullable=True)
 	container_persistent_profile_path = db.Column(db.String(255), nullable=True)
+	container_network = db.Column(db.String(255), nullable=True)  # Docker network to use for this droplet
 	server_ip = db.Column(db.String(255), nullable=True)
 	server_port = db.Column(db.Integer, nullable=True)
 	server_username = db.Column(db.String(255), nullable=True)

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -30,19 +30,6 @@ def get_container_ip(container, droplet):
 	
 	return "N/A"
 
-def get_git_commit():
-	"""Get the current git commit hash"""
-	# First try to use the commit hash from __init__.py which is set during Docker build
-	if __commit__ != "Unknown":
-		return __commit__[:7] if len(__commit__) >= 7 else __commit__
-	
-	# If that fails, try to get it directly using Git commands, for local development in venv
-	try:
-		commit_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD'], stderr=subprocess.STDOUT).decode('utf-8').strip()
-		return commit_hash[:7]  # Return short hash (first 7 characters)
-	except (subprocess.CalledProcessError, FileNotFoundError):
-		return "Unknown"
-
 @admin_bp.route('/system_info', methods=['GET'])
 @login_required
 def api_admin_system():

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -790,4 +790,26 @@ def api_admin_image_logs():
 		return jsonify({
 			"success": False,
 			"error": f"Failed to fetch image logs: {str(e)}"
-		}), 500 
+		}), 500
+
+@admin_bp.route('/networks', methods=['GET'])
+def api_admin_networks():
+	"""Get list of available Docker networks"""
+	if not Permissions.check_permission(current_user.id, Permissions.VIEW_DROPLETS):
+		return jsonify({"success": False, "error": "Unauthorized"}), 403
+
+	if not utils.docker.is_docker_available():
+		return jsonify({
+			"success": False,
+			"error": "Docker service is not available"
+		}), 503
+	
+	try:
+		networks = utils.docker.list_available_networks()
+		return jsonify({
+			"success": True,
+			"networks": networks
+		})
+	except Exception as e:
+		log("ERROR", f"Error listing networks: {str(e)}")
+		return jsonify({"success": False, "error": str(e)}), 500

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -805,10 +805,20 @@ def api_admin_networks():
 		}), 503
 	
 	try:
-		networks = utils.docker.list_available_networks()
+		all_networks = utils.docker.list_available_networks()
+		
+		# Filter networks: only include default network and networks starting with lan_ or vlan_
+		filtered_networks = []
+		for network in all_networks:
+			network_name = network["name"]
+			if (network_name == "flowcase_default_network" or
+				network_name.startswith("lan_") or
+				network_name.startswith("vlan_")):
+				filtered_networks.append(network)
+		
 		return jsonify({
 			"success": True,
-			"networks": networks
+			"networks": filtered_networks
 		})
 	except Exception as e:
 		log("ERROR", f"Error listing networks: {str(e)}")

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -16,15 +16,19 @@ import subprocess
 admin_bp = Blueprint('admin', __name__)
 
 def get_container_ip(container, droplet):
-	"""Get the IP address of a container, checking the droplet's network first"""
+	"""Get the IP address of a container, prioritizing the default network for nginx connectivity"""
 	networks = container.attrs['NetworkSettings']['Networks']
 	
-	# First check the droplet's specified network if available
+	# First check the default network for nginx connectivity
+	if 'flowcase_default_network' in networks and networks['flowcase_default_network']['IPAddress']:
+		return networks['flowcase_default_network']['IPAddress']
+	
+	# If not found, check the droplet's specified network
 	if droplet.container_network and droplet.container_network in networks:
 		return networks[droplet.container_network]['IPAddress']
 	
 	# Fall back to other networks
-	for network_name in ['flowcase_default_network', 'default_network', 'bridge']:
+	for network_name in ['default_network', 'bridge']:
 		if network_name in networks and networks[network_name]['IPAddress']:
 			return networks[network_name]['IPAddress']
 	

--- a/routes/droplet.py
+++ b/routes/droplet.py
@@ -115,6 +115,7 @@ def get_instances():
 			"id": instance.id,
 			"created_at": instance.created_at,
 			"updated_at": instance.updated_at,
+			"ip": ip,
 			"droplet": {
 				"id": droplet.id,
 				"display_name": droplet.display_name,
@@ -127,7 +128,10 @@ def get_instances():
 				"container_memory": droplet.container_memory,
 				"server_ip": droplet.server_ip,
 				"server_port": droplet.server_port,
-			}
+			},
+			"user": {
+				"username": instance.username,
+			},
 		})
  
 	return jsonify(response)

--- a/routes/droplet.py
+++ b/routes/droplet.py
@@ -128,10 +128,7 @@ def get_instances():
 				"container_memory": droplet.container_memory,
 				"server_ip": droplet.server_ip,
 				"server_port": droplet.server_port,
-			},
-			"user": {
-				"username": instance.username,
-			},
+			}
 		})
  
 	return jsonify(response)

--- a/static/js/dashboard/admin.js
+++ b/static/js/dashboard/admin.js
@@ -1128,8 +1128,11 @@ function ShowEditDroplet(instance_id = null)
 
 		<div class="admin-modal-card">
 			<p>Docker Network</p>
-			<input type="text" id="admin-edit-droplet-network" value="${ droplet != null ? droplet.container_network ? droplet.container_network : "" : "" }">
-			<small>Leave empty to use the default network (flowcase_default_network)</small>
+			<select id="admin-edit-droplet-network">
+				<option value="">Default Network (flowcase_default_network)</option>
+				<!-- Network options will be populated dynamically -->
+			</select>
+			<small>Select a network for this droplet</small>
 		</div>
 	</div>
 
@@ -1159,6 +1162,25 @@ function ShowEditDroplet(instance_id = null)
 	`;
 
 	ChangeDropletType();
+	
+	// Populate network dropdown with available networks
+	FetchAdminNetworks(function(json) {
+		var networkDropdown = document.getElementById('admin-edit-droplet-network');
+		
+		// Add networks from the API response
+		json.networks.forEach(network => {
+			var option = document.createElement('option');
+			option.value = network.name;
+			option.text = network.name;
+			
+			// Select the current network if editing an existing droplet
+			if (droplet != null && droplet.container_network === network.name) {
+				option.selected = true;
+			}
+			
+			networkDropdown.appendChild(option);
+		});
+	});
 }
 
 function ChangeDropletType()

--- a/static/js/dashboard/admin.js
+++ b/static/js/dashboard/admin.js
@@ -1123,6 +1123,12 @@ function ShowEditDroplet(instance_id = null)
 			<p>Persistant Profile Path</p>
 			<input type="text" id="admin-edit-droplet-persistent-profile" value="${ droplet != null ? droplet.container_persistent_profile_path ? droplet.container_persistent_profile_path : "" : "" }">
 		</div>
+
+		<div class="admin-modal-card">
+			<p>Docker Network</p>
+			<input type="text" id="admin-edit-droplet-network" value="${ droplet != null ? droplet.container_network ? droplet.container_network : "" : "" }">
+			<small>Leave empty to use the default network (flowcase_default_network)</small>
+		</div>
 	</div>
 
 	<div id="admin-droplet-edit-server-only">
@@ -1240,6 +1246,7 @@ function SaveDroplet(droplet_id = null)
 		"container_cores": document.getElementById('admin-edit-droplet-cores').value,
 		"container_memory": document.getElementById('admin-edit-droplet-memory').value,
 		"container_persistent_profile_path": document.getElementById('admin-edit-droplet-persistent-profile').value,
+		"container_network": document.getElementById('admin-edit-droplet-network').value,
 		"server_ip": document.getElementById('admin-edit-droplet-ip-address').value,
 		"server_port": document.getElementById('admin-edit-droplet-port').value,
 		"server_username": document.getElementById('admin-edit-droplet-username').value,

--- a/static/js/dashboard/admin.js
+++ b/static/js/dashboard/admin.js
@@ -151,12 +151,14 @@ function AdminChangeTab(tab, element = null)
 					<tr>
 						<th>Name</th>
 						<th>Image / IP</th>
+						<th>Network</th>
 						${userInfo.permissions.perm_edit_droplets ? `<th>Actions</th>` : ''}
 					</tr>
 					${json["droplets"].map(droplet => `
 						<tr>
 							<td><div><img src="${droplet.image_path ? droplet.image_path : '/static/img/droplet_default.jpg'}"><p>${droplet.display_name}</p></div></td>
 							<td>${droplet.droplet_type == "container" ? droplet.container_docker_image : droplet.server_ip}</td>
+							<td>${droplet.container_network ? droplet.container_network : 'default'}</td>
 							${userInfo.permissions.perm_edit_droplets ? `<td class="admin-modal-table-actions">
 								<i class="fas fa-edit" onclick="ShowEditDroplet('${droplet.id}')"></i>
 								<i class="fas fa-trash" onclick="AdminDeleteDroplet('${droplet.id}')"></i>

--- a/static/js/dashboard/admin.js
+++ b/static/js/dashboard/admin.js
@@ -632,6 +632,34 @@ function FetchAdminInstances(callback)
 	console.log("Retrieving instances...");
 }
 
+function FetchAdminNetworks(callback)
+{
+	var url = "/api/admin/networks";
+	var xhr = new XMLHttpRequest();
+	xhr.open("GET", url, true);
+	xhr.setRequestHeader("Content-Type", "application/json");
+	xhr.onreadystatechange = function () {
+		if (xhr.readyState === 4) {
+			var json = JSON.parse(xhr.responseText);
+			if (json["success"] == true) {
+				callback(json);
+			}
+			else
+			{
+				if (json["error"] != null) {
+					CreateNotification(json["error"], "error");
+				}
+				else {
+					CreateNotification("An error occurred while retrieving the networks. Please try again later.", "error");
+				}
+			}
+		}
+	};
+	xhr.send();
+
+	console.log("Retrieving networks...");
+}
+
 function FetchAdminGroups(callback)
 {
 	var url = "/api/admin/groups";


### PR DESCRIPTION
This implements the ability to connect container droplets to docker networks:
- allows to select a custom networks in create / edit droplet dialog
- looks for existing docker networks
- docker networks are filtered and need to start with lan_* or vlan*

How to create network on the docker host?
- add NIC to with dedicated LAN to your host
- run for e.g.: docker network create -d macvlan --subnet=192.168.100.0/24 --gateway=192.168.100.1 --ip-range=192.168.100.240/28 -o parent=<interface> vlan_test
- of course the has access to this network. So additional firewall rule to be applied.

 